### PR TITLE
expose LaSalles and ODEs modules to docbuild

### DIFF
--- a/LeanForControl.lean
+++ b/LeanForControl.lean
@@ -4,3 +4,7 @@ import LeanForControl.LinearSystems.Controllability
 import LeanForControl.LinearSystems.Hautus
 import LeanForControl.LinearSystems.MatrixLemmas
 import LeanForControl.LinearSystems.Observability
+import LeanForControl.Lyapunov.LaSalles
+import LeanForControl.ODEs.comparison_lemma
+import LeanForControl.ODEs.gronwall_bellman
+import LeanForControl.ODEs.ODE_properties


### PR DESCRIPTION
Imports four previously-orphaned modules into the docbuild root so doc-gen4 renders their pages:

- LeanForControl.Lyapunov.LaSalles
- LeanForControl.ODEs.comparison_lemma
- LeanForControl.ODEs.gronwall_bellman
- LeanForControl.ODEs.ODE_properties

All four already build via `lake build`; only their visibility to the docs site changes. `LeanForControl.ODEs.scratchpad` is intentionally left unimported (sandbox namespace).

No source edits; no blueprint annotations.