### PR TITLE
blueprint + docbuild coverage for Lyapunov Defs + Autonomous

### DIFF
--- a/LeanForControl.lean
+++ b/LeanForControl.lean
@@ -4,6 +4,8 @@ import LeanForControl.LinearSystems.Controllability
 import LeanForControl.LinearSystems.Hautus
 import LeanForControl.LinearSystems.MatrixLemmas
 import LeanForControl.LinearSystems.Observability
+import LeanForControl.Lyapunov.Defs
+import LeanForControl.Lyapunov.Autonomous
 import LeanForControl.Lyapunov.LaSalles
 import LeanForControl.ODEs.comparison_lemma
 import LeanForControl.ODEs.gronwall_bellman

--- a/LeanForControl/Lyapunov/Autonomous.lean
+++ b/LeanForControl/Lyapunov/Autonomous.lean
@@ -1,6 +1,7 @@
 import Mathlib.Analysis.Calculus.Deriv.MeanValue
 import Mathlib.Topology.Order.MonotoneConvergence
 import LeanForControl.Lyapunov.Defs
+import Architect
 
 variable {n : ℕ}
 
@@ -244,6 +245,32 @@ lemma sublevel_set_invariant
 -- (8) For t ∈ [0, T*], ‖φ t - x_eq‖ ≤ ε' ≤ ε₀ → φ t ∈ closedBall ε₀ ⊆ D.
 -- (9) V_nonincreasing_on on [0, T*] → V(φ(T*)) ≤ V(φ 0) < m.
 -- (10) φ(T*) ∈ sphere ε' → V(φ(T*)) ≥ m. Contradiction.
+/-- **Milestone (Lyapunov stability theorem).**
+
+If `V` is a local Lyapunov function for `ẋ = f(x)` at `x_eq` on an open
+domain `D`, then `x_eq` is Lyapunov stable. -/
+@[blueprint "thm:lyapunov-stable"
+  (statement := /-- Let $\dot{x} = f(x)$ have an equilibrium $x_{\mathrm{eq}}$.
+    If $V : \mathbb{R}^{n} \to \mathbb{R}$ is a local Lyapunov function for
+    $f$ at $x_{\mathrm{eq}}$ on an open domain $D \ni x_{\mathrm{eq}}$
+    (see \cref{def:isLocalLyapunovFunction}), then $x_{\mathrm{eq}}$ is
+    Lyapunov stable (see \cref{def:lyapunovStable}). -/)
+  (proof := /-- Pick $\varepsilon_{0} > 0$ small enough that the closed ball
+    of radius $\varepsilon_{0}$ around $x_{\mathrm{eq}}$ sits inside $D$. For
+    $\varepsilon \le \varepsilon_{0}$ let
+    $m = \min_{\|y - x_{\mathrm{eq}}\| = \varepsilon} V(y) > 0$ (compactness
+    of the sphere plus positive-definiteness of $V$). Continuity of $V$ at
+    $x_{\mathrm{eq}}$ with $V(x_{\mathrm{eq}}) = 0$ gives $\delta > 0$ with
+    $V(y) < m$ whenever $\|y - x_{\mathrm{eq}}\| < \delta$. Suppose for
+    contradiction some trajectory $\varphi$ with
+    $\|\varphi(0) - x_{\mathrm{eq}}\| < \delta$ has
+    $\|\varphi(t^{*}) - x_{\mathrm{eq}}\| \ge \varepsilon$ for some
+    $t^{*} \ge 0$. By IVT and minimality there is a first time $T^{*}$ where
+    $\|\varphi(T^{*}) - x_{\mathrm{eq}}\| = \varepsilon$; on $[0, T^{*}]$
+    the trajectory stays in $D$, so $V \circ \varphi$ is non-increasing
+    (Lie derivative $\le 0$), giving $V(\varphi(T^{*})) \le V(\varphi(0)) <
+    m$. But $\varphi(T^{*})$ lies on the sphere of radius $\varepsilon$ so
+    $V(\varphi(T^{*})) \ge m$. Contradiction. -/)]
 theorem lyapunov_stable
     {D : Set ℝⁿ} {f : ℝⁿ → ℝⁿ} {V : ℝⁿ → ℝ} {x_eq : ℝⁿ} (hn : 0 < n)
     (hV : IsLocalLyapunovFunction f V x_eq D) :
@@ -535,6 +562,24 @@ lemma tendsto_of_V_tendsto_zero
     hV_tendsto
 
 -- Theorem 4.1, Parts 2 & 3: IsStrictLyapunovFunction → GlobalAsymptoticStable.
+/-- **Milestone (asymptotic stability via strict Lyapunov function).**
+
+A strict global Lyapunov function with continuous dynamics implies global
+asymptotic stability. -/
+@[blueprint "thm:lyapunov-asymptotic-stable"
+  (statement := /-- Let $\dot{x} = f(x)$ with $f$ continuous and let
+    $V : \mathbb{R}^{n} \to \mathbb{R}$ be a strict global Lyapunov function
+    for $f$ at $x_{\mathrm{eq}}$ (see \cref{def:isStrictLyapunovFunction}).
+    Then $x_{\mathrm{eq}}$ is globally asymptotically stable
+    (see \cref{def:globalAsymptoticStable}). -/)
+  (proof := /-- Lyapunov stability is \cref{thm:lyapunov-stable} applied to
+    the local-Lyapunov part of the strict hypothesis. For attractivity, fix
+    a trajectory $\varphi$. Compactness of every sublevel set
+    (see \cref{def:isStrictLyapunovFunction}) confines $\varphi$ to the
+    compact set $\{V \le V(\varphi(0))\}$, and $V \circ \varphi$ is
+    non-increasing, hence converges to some $L \ge 0$. A LaSalle-style
+    argument using the strict Lie-derivative inequality forces $L = 0$, and
+    a continuity argument then yields $\varphi(t) \to x_{\mathrm{eq}}$. -/)]
 theorem lyapunov_asymptotic_stable
     {f : ℝⁿ → ℝⁿ} {V : ℝⁿ → ℝ} {x_eq : ℝⁿ} (hn : 0 < n)
     (hV : IsStrictLyapunovFunction f V x_eq)
@@ -549,6 +594,22 @@ theorem lyapunov_asymptotic_stable
     exact tendsto_of_V_tendsto_zero hV htraj hL_tendsto
 
 -- Corollary: IsAsymptoticLyapunovFunction → GAS (Khalil's classical form).
+/-- **Milestone (Khalil's classical form of GAS).**
+
+A radially unbounded, positive definite `C¹` Lyapunov function with strict
+negative-definite Lie derivative implies global asymptotic stability. -/
+@[blueprint "thm:lyapunov-global-asymptotic-stable"
+  (statement := /-- Let $\dot{x} = f(x)$ with $f$ continuous, and let
+    $V : \mathbb{R}^{n} \to \mathbb{R}$ be an asymptotic Lyapunov function
+    for $f$ at $x_{\mathrm{eq}}$
+    (see \cref{def:isAsymptoticLyapunovFunction}). Then $x_{\mathrm{eq}}$
+    is globally asymptotically stable
+    (see \cref{def:globalAsymptoticStable}). -/)
+  (proof := /-- Radial unboundedness combined with
+    \cref{lem:isCompact-sublevel-set} converts the asymptotic Lyapunov
+    function into a strict Lyapunov function in the sense of
+    \cref{def:isStrictLyapunovFunction}. The conclusion then follows from
+    \cref{thm:lyapunov-asymptotic-stable}. -/)]
 theorem lyapunov_global_asymptotic_stable
     {f : ℝⁿ → ℝⁿ} {V : ℝⁿ → ℝ} {x_eq : ℝⁿ} (hn : 0 < n)
     (hV : IsAsymptoticLyapunovFunction f V x_eq)
@@ -567,6 +628,25 @@ theorem lyapunov_global_asymptotic_stable
 --     V_tendsto_limit (with compactness replacing radial unboundedness) gives V(φ t) → L ≥ 0.
 --     V_limit_zero on the compact Ωc₀ gives L = 0.
 --     tendsto_of_V_tendsto_zero (local version) gives φ t → x_eq.
+/-- **Milestone (local asymptotic stability).**
+
+A strict local Lyapunov function with a compact sublevel set inside the
+domain implies local asymptotic stability. -/
+@[blueprint "thm:lyapunov-local-asymptotic-stable"
+  (statement := /-- Let $\dot{x} = f(x)$ with $f$ continuous and let
+    $V : \mathbb{R}^{n} \to \mathbb{R}$ be a strict local Lyapunov function
+    for $f$ at $x_{\mathrm{eq}}$ on an open set $D \ni x_{\mathrm{eq}}$
+    (see \cref{def:isStrictLocalLyapunovFunction}). Then $x_{\mathrm{eq}}$
+    is locally asymptotically stable
+    (see \cref{def:localAsymptoticStable}). -/)
+  (proof := /-- Lyapunov stability is \cref{thm:lyapunov-stable} applied to
+    the local-Lyapunov part of the strict hypothesis. For the basin of
+    attraction take the compact sublevel set $\Omega_{c_{0}}(V) \subseteq D$
+    supplied by the hypothesis; trajectories starting in the interior of
+    $\Omega_{c_{0}}(V)$ stay inside (sublevel-set invariance), so $V \circ
+    \varphi$ converges to some $L \ge 0$. The strict Lie-derivative
+    inequality on the compact $\Omega_{c_{0}}(V)$ forces $L = 0$, and a
+    continuity argument then gives $\varphi(t) \to x_{\mathrm{eq}}$. -/)]
 theorem lyapunov_local_asymptotic_stable
     {D : Set ℝⁿ} {f : ℝⁿ → ℝⁿ} {V : ℝⁿ → ℝ} {x_eq : ℝⁿ} (hn : 0 < n)
     (hV : IsStrictLocalLyapunovFunction f V x_eq D)

--- a/LeanForControl/Lyapunov/Defs.lean
+++ b/LeanForControl/Lyapunov/Defs.lean
@@ -4,50 +4,103 @@ import Mathlib.Analysis.Calculus.ContDiff.Defs
 import Mathlib.Topology.MetricSpace.Basic
 import Mathlib.Topology.MetricSpace.Bounded
 import Mathlib.Analysis.Normed.Group.Bounded
+import Architect
 variable {n : ℕ}
 
 local notation "ℝⁿ" => EuclideanSpace ℝ (Fin n)
 
 /-! ## Class K and K∞ functions -/
 
--- α : [0, ∞) → ℝ, continuous, zero at zero, strictly increasing.
+/-- A function `α : [0, ∞) → ℝ` is of class `𝒦` when it is continuous, zero at
+zero, and strictly increasing on `[0, ∞)`. -/
+@[blueprint "def:isClassK"
+  (statement := /-- A function $\alpha : [0, \infty) \to \mathbb{R}$ is of
+    \emph{class $\mathcal{K}$} when it is continuous on $[0, \infty)$, vanishes
+    at the origin ($\alpha(0) = 0$), and is strictly increasing on
+    $[0, \infty)$. Class-$\mathcal{K}$ functions are the standard comparison
+    functions used to bound a Lyapunov function from below. -/)]
 def IsClassK (α : ℝ → ℝ) : Prop :=
   ContinuousOn α (Set.Ici 0) ∧ α 0 = 0 ∧ StrictMonoOn α (Set.Ici 0)
 
--- Class K and radially unbounded: α(r) → ∞ as r → ∞.
+/-- Class `𝒦` and radially unbounded: `α(r) → ∞` as `r → ∞`. -/
+@[blueprint "def:isClassKInfty"
+  (statement := /-- A class-$\mathcal{K}$ function $\alpha$
+    (see \cref{def:isClassK}) is of \emph{class $\mathcal{K}_{\infty}$} when it
+    is moreover radially unbounded: $\alpha(r) \to \infty$ as $r \to \infty$.
+    Class-$\mathcal{K}_{\infty}$ functions are used to sandwich a Lyapunov
+    function in the global setting. -/)]
 def IsClassKInfty (α : ℝ → ℝ) : Prop :=
   IsClassK α ∧ Filter.Tendsto α Filter.atTop Filter.atTop
 
 /-! ## System primitives -/
 
--- φ is a global solution of ẋ = f(x), defined for all t ∈ ℝ.
+/-- `φ` is a global solution of `ẋ = f(x)`, defined for all `t ∈ ℝ`. -/
+@[blueprint "def:isTrajectory"
+  (statement := /-- A curve $\varphi : \mathbb{R} \to \mathbb{R}^{n}$ is a
+    \emph{trajectory} of the autonomous system $\dot{x} = f(x)$ when it is
+    differentiable at every $t \in \mathbb{R}$ with
+    $\dot{\varphi}(t) = f(\varphi(t))$. Trajectories are required to exist
+    globally in time. -/)]
 def IsTrajectory (φ : ℝ → ℝⁿ) (f : ℝⁿ → ℝⁿ) : Prop :=
   ∀ t : ℝ, HasDerivAt φ (f (φ t)) t
 
--- x_eq is an equilibrium point: f(x_eq) = 0.
+/-- `x_eq` is an equilibrium point: `f(x_eq) = 0`. -/
+@[blueprint "def:isEquilibrium"
+  (statement := /-- A point $x_{\mathrm{eq}} \in \mathbb{R}^{n}$ is an
+    \emph{equilibrium} of $\dot{x} = f(x)$ when $f(x_{\mathrm{eq}}) = 0$.
+    Equivalently, the constant curve $\varphi \equiv x_{\mathrm{eq}}$ is a
+    trajectory (see \cref{def:isTrajectory}). -/)]
 def IsEquilibrium (f : ℝⁿ → ℝⁿ) (x_eq : ℝⁿ) : Prop :=
   f x_eq = 0
 
 /-! ## Stability predicates -/
 
--- Standard ε-δ Lyapunov stability.
+/-- Standard ε–δ Lyapunov stability. -/
+@[blueprint "def:lyapunovStable"
+  (statement := /-- An equilibrium $x_{\mathrm{eq}}$ of $\dot{x} = f(x)$ is
+    \emph{Lyapunov stable} when, for every $\varepsilon > 0$, there exists
+    $\delta > 0$ such that every trajectory $\varphi$
+    (see \cref{def:isTrajectory}) with
+    $\|\varphi(0) - x_{\mathrm{eq}}\| < \delta$ satisfies
+    $\|\varphi(t) - x_{\mathrm{eq}}\| < \varepsilon$ for all $t \ge 0$. -/)]
 def LyapunovStable (f : ℝⁿ → ℝⁿ) (x_eq : ℝⁿ) : Prop :=
   ∀ ε > 0, ∃ δ > 0, ∀ φ : ℝ → ℝⁿ,
     IsTrajectory φ f → ‖φ 0 - x_eq‖ < δ → ∀ t ≥ 0, ‖φ t - x_eq‖ < ε
 
--- Lyapunov stable and trajectories starting near x_eq converge to x_eq.
+/-- Lyapunov stable and trajectories starting near `x_eq` converge to
+`x_eq`. -/
+@[blueprint "def:localAsymptoticStable"
+  (statement := /-- An equilibrium $x_{\mathrm{eq}}$ of $\dot{x} = f(x)$ is
+    \emph{locally asymptotically stable} when it is Lyapunov stable
+    (see \cref{def:lyapunovStable}) and there exists $c > 0$ such that every
+    trajectory $\varphi$ with $\|\varphi(0) - x_{\mathrm{eq}}\| < c$ satisfies
+    $\varphi(t) \to x_{\mathrm{eq}}$ as $t \to \infty$. -/)]
 def LocalAsymptoticStable (f : ℝⁿ → ℝⁿ) (x_eq : ℝⁿ) : Prop :=
   LyapunovStable f x_eq ∧
   ∃ c > 0, ∀ φ : ℝ → ℝⁿ,
     IsTrajectory φ f → ‖φ 0 - x_eq‖ < c → Filter.Tendsto φ Filter.atTop (nhds x_eq)
 
--- Lyapunov stable and every trajectory converges to x_eq.
+/-- Lyapunov stable and every trajectory converges to `x_eq`. -/
+@[blueprint "def:globalAsymptoticStable"
+  (statement := /-- An equilibrium $x_{\mathrm{eq}}$ of $\dot{x} = f(x)$ is
+    \emph{globally asymptotically stable} when it is Lyapunov stable
+    (see \cref{def:lyapunovStable}) and every trajectory $\varphi$ of the
+    system satisfies $\varphi(t) \to x_{\mathrm{eq}}$ as $t \to \infty$. -/)]
 def GlobalAsymptoticStable (f : ℝⁿ → ℝⁿ) (x_eq : ℝⁿ) : Prop :=
   LyapunovStable f x_eq ∧
   ∀ φ : ℝ → ℝⁿ, IsTrajectory φ f → Filter.Tendsto φ Filter.atTop (nhds x_eq)
 
 /-! ## Sublevel sets -/
 
+/-- The `c`-sublevel set of `V`. -/
+@[blueprint "def:sublevelSet"
+  (statement := /-- For $V : \mathbb{R}^{n} \to \mathbb{R}$ and $c \in
+    \mathbb{R}$, the \emph{$c$-sublevel set} of $V$ is
+    \[
+      \Omega_{c}(V) = \{ x \in \mathbb{R}^{n} : V(x) \le c \}.
+    \]
+    Sublevel sets of Lyapunov functions are the canonical invariant
+    neighborhoods used in stability proofs. -/)]
 def SublevelSet (V : ℝⁿ → ℝ) (c : ℝ) : Set ℝⁿ := {x | V x ≤ c}
 
 /-! ## Lyapunov function structures
@@ -67,8 +120,22 @@ agreeing with the original on a neighborhood of x_eq.
 
 The Lie derivative DV(x)[f(x)] = fderiv ℝ V x (f x). -/
 
--- Local stability: V positive definite on D, Lie derivative ≤ 0 on D.
--- D is an open neighborhood of x_eq; V is globally smooth (for chain rule).
+/-- Local Lyapunov function on an open domain `D ∋ x_eq`. `V` is globally
+continuous and differentiable; positivity and Lie-derivative conditions hold
+only on `D`. -/
+@[blueprint "def:isLocalLyapunovFunction"
+  (statement := /-- A function $V : \mathbb{R}^{n} \to \mathbb{R}$ is a
+    \emph{local Lyapunov function} for $\dot{x} = f(x)$ at an equilibrium
+    $x_{\mathrm{eq}}$ on an open set $D \ni x_{\mathrm{eq}}$ when
+    \begin{enumerate}
+      \item $V$ is continuous and (globally) differentiable on $\mathbb{R}^{n}$,
+      \item $V(x_{\mathrm{eq}}) = 0$,
+      \item $V(x) > 0$ for all $x \in D \setminus \{x_{\mathrm{eq}}\}$,
+      \item the Lie derivative satisfies
+        $\mathrm{D}V(x)\bigl[f(x)\bigr] \le 0$ for all $x \in D$.
+    \end{enumerate}
+    Global smoothness is for the chain rule; only on $D$ are positivity and
+    monotonicity required. -/)]
 structure IsLocalLyapunovFunction (f : ℝⁿ → ℝⁿ) (V : ℝⁿ → ℝ) (x_eq : ℝⁿ) (D : Set ℝⁿ) : Prop where
   hD_open     : IsOpen D
   hD_mem      : x_eq ∈ D
@@ -78,9 +145,26 @@ structure IsLocalLyapunovFunction (f : ℝⁿ → ℝⁿ) (V : ℝⁿ → ℝ) (
   hpos        : ∀ x ∈ D, x ≠ x_eq → 0 < V x
   hLie_nonpos : ∀ x ∈ D, fderiv ℝ V x (f x) ≤ 0
 
--- Local asymptotic stability: strict Lie derivative on D, compact sublevel set inside D.
--- hcompact: ∃ c > 0 with Ωc ⊆ D and Ωc compact. This replaces radial unboundedness
--- and is satisfied whenever D is bounded or V grows toward the boundary of D.
+/-- Strict local Lyapunov function: strict Lie-derivative inequality on `D`
+plus a compact sublevel set contained in `D`. -/
+@[blueprint "def:isStrictLocalLyapunovFunction"
+  (statement := /-- A function $V : \mathbb{R}^{n} \to \mathbb{R}$ is a
+    \emph{strict local Lyapunov function} for $\dot{x} = f(x)$ at an
+    equilibrium $x_{\mathrm{eq}}$ on an open set $D \ni x_{\mathrm{eq}}$ when
+    \begin{enumerate}
+      \item $V$ is continuous and $C^{1}$ on $\mathbb{R}^{n}$,
+      \item $V(x_{\mathrm{eq}}) = 0$,
+      \item $V(x) > 0$ for all $x \in D \setminus \{x_{\mathrm{eq}}\}$,
+      \item $f(x_{\mathrm{eq}}) = 0$,
+      \item the Lie derivative is strictly negative:
+        $\mathrm{D}V(x)\bigl[f(x)\bigr] < 0$ for all $x \in D \setminus
+        \{x_{\mathrm{eq}}\}$,
+      \item there exists $c > 0$ such that the sublevel set
+        $\Omega_{c}(V)$ (see \cref{def:sublevelSet}) is contained in $D$ and
+        compact.
+    \end{enumerate}
+    The compact-sublevel hypothesis replaces radial unboundedness in the local
+    setting. -/)]
 structure IsStrictLocalLyapunovFunction
     (f : ℝⁿ → ℝⁿ) (V : ℝⁿ → ℝ) (x_eq : ℝⁿ) (D : Set ℝⁿ) : Prop where
   hD_open   : IsOpen D
@@ -110,8 +194,23 @@ structure IsStrictLocalLyapunovFunction
 --   hLie_neg  : ∀ x ∈ D, x ≠ x_eq → fderiv ℝ V x (f x) < 0
 --   hcompact  : ∃ c > 0, SublevelSet V c ⊆ D ∧ IsCompact (SublevelSet V c)
 
--- Global stability: strict Lie derivative + compact sublevel sets everywhere → GAS.
--- hbounded_sublevel encodes coercivity; in ℝⁿ this is equivalent to radial unboundedness.
+/-- Global strict Lyapunov function: strict Lie derivative everywhere plus
+coercivity (every sublevel set is compact). -/
+@[blueprint "def:isStrictLyapunovFunction"
+  (statement := /-- A function $V : \mathbb{R}^{n} \to \mathbb{R}$ is a
+    \emph{strict (global) Lyapunov function} for $\dot{x} = f(x)$ at an
+    equilibrium $x_{\mathrm{eq}}$ when
+    \begin{enumerate}
+      \item $V$ is continuous and $C^{1}$,
+      \item $V(x_{\mathrm{eq}}) = 0$ and $V(x) > 0$ for all $x \neq
+        x_{\mathrm{eq}}$,
+      \item $f(x_{\mathrm{eq}}) = 0$,
+      \item $\mathrm{D}V(x)\bigl[f(x)\bigr] < 0$ for all $x \neq
+        x_{\mathrm{eq}}$,
+      \item every sublevel set $\{V \le c\}$ is compact (coercivity).
+    \end{enumerate}
+    On $\mathbb{R}^{n}$ the coercivity condition is equivalent to radial
+    unboundedness of $V$. -/)]
 structure IsStrictLyapunovFunction (f : ℝⁿ → ℝⁿ) (V : ℝⁿ → ℝ) (x_eq : ℝⁿ) : Prop where
   hcont             : Continuous V
   hV_c1             : ContDiff ℝ 1 V
@@ -121,7 +220,18 @@ structure IsStrictLyapunovFunction (f : ℝⁿ → ℝⁿ) (V : ℝⁿ → ℝ) 
   hLie_neg          : ∀ x : ℝⁿ, x ≠ x_eq → fderiv ℝ V x (f x) < 0
   hbounded_sublevel : ∀ c : ℝ, IsCompact {x : ℝⁿ | V x ≤ c}
 
--- Global Lyapunov function with quantitative K∞ sandwich bounds.
+/-- Global Lyapunov function with quantitative class-K-infinity sandwich
+bounds. -/
+@[blueprint "def:isGlobalLyapunovFunction"
+  (statement := /-- A function $V : \mathbb{R}^{n} \to \mathbb{R}$ is a
+    \emph{quantitative global Lyapunov function} for $\dot{x} = f(x)$ at an
+    equilibrium $x_{\mathrm{eq}}$ when it is continuous, differentiable,
+    sandwiched between two class-$\mathcal{K}_{\infty}$ functions
+    (see \cref{def:isClassKInfty}) $\alpha_{1}, \alpha_{2}$ as
+    $\alpha_{1}(\|x - x_{\mathrm{eq}}\|) \le V(x) \le
+    \alpha_{2}(\|x - x_{\mathrm{eq}}\|)$,
+    and has non-positive Lie derivative
+    $\mathrm{D}V(x) \cdot f(x) \le 0$ for all $x$. -/)]
 structure IsGlobalLyapunovFunction (f : ℝⁿ → ℝⁿ) (V : ℝⁿ → ℝ) (x_eq : ℝⁿ) : Prop where
   hcont       : Continuous V
   hV_diff     : Differentiable ℝ V
@@ -130,8 +240,24 @@ structure IsGlobalLyapunovFunction (f : ℝⁿ → ℝⁿ) (V : ℝⁿ → ℝ) 
   hLie_nonpos : ∀ x : ℝⁿ, fderiv ℝ V x (f x) ≤ 0
 
 
--- Classical formulation for GAS: C¹, positive definite, strict Lie derivative, radially unbounded.
--- This implies IsStrictLyapunovFunction (via isCompact_sublevel_set in Autonomous.lean).
+/-- Classical Lyapunov function for global asymptotic stability: `C¹`, positive
+definite, strict Lie derivative, radially unbounded. -/
+@[blueprint "def:isAsymptoticLyapunovFunction"
+  (statement := /-- A function $V : \mathbb{R}^{n} \to \mathbb{R}$ is an
+    \emph{asymptotic Lyapunov function} for $\dot{x} = f(x)$ at an
+    equilibrium $x_{\mathrm{eq}}$ when
+    \begin{enumerate}
+      \item $V$ is continuous and $C^{1}$,
+      \item $V(x_{\mathrm{eq}}) = 0$ and $V(x) > 0$ for all $x \neq
+        x_{\mathrm{eq}}$,
+      \item $f(x_{\mathrm{eq}}) = 0$,
+      \item $\mathrm{D}V(x)\bigl[f(x)\bigr] < 0$ for all $x \neq
+        x_{\mathrm{eq}}$,
+      \item $V$ is radially unbounded: $V(x) \to \infty$ as $\|x\| \to
+        \infty$.
+    \end{enumerate}
+    Together with $\cref{lem:isCompact-sublevel-set}$ this implies the
+    coercivity hypothesis of \cref{def:isStrictLyapunovFunction}. -/)]
 structure IsAsymptoticLyapunovFunction (f : ℝⁿ → ℝⁿ) (V : ℝⁿ → ℝ) (x_eq : ℝⁿ) : Prop where
   hcont    : Continuous V
   hV_c1    : ContDiff ℝ 1 V
@@ -141,15 +267,33 @@ structure IsAsymptoticLyapunovFunction (f : ℝⁿ → ℝⁿ) (V : ℝⁿ → �
   hLie_neg : ∀ x : ℝⁿ, x ≠ x_eq → fderiv ℝ V x (f x) < 0
   hradial  : Filter.Tendsto V (Filter.comap norm Filter.atTop) Filter.atTop
 
--- A set S is positively invariant: trajectories starting in S stay in S for t ≥ 0.
+/-- A set `S` is positively invariant: trajectories starting in `S` stay in
+`S` for `t ≥ 0`. -/
+@[blueprint "def:isPositivelyInvariant"
+  (statement := /-- A set $S \subseteq \mathbb{R}^{n}$ is \emph{positively
+    invariant} for $\dot{x} = f(x)$ when every trajectory $\varphi$
+    (see \cref{def:isTrajectory}) with $\varphi(0) \in S$ satisfies
+    $\varphi(t) \in S$ for all $t \ge 0$. Positively invariant sets are the
+    natural confinement regions in Lyapunov arguments. -/)]
 def IsPositivelyInvariant (S : Set ℝⁿ) (f : ℝⁿ → ℝⁿ) : Prop :=
   ∀ φ : ℝ → ℝⁿ, IsTrajectory φ f → φ 0 ∈ S → ∀ t ≥ 0, φ t ∈ S
 
--- Sublevel sets of a radially unbounded continuous function are compact.
--- Proof:
---   (1) Closed: V ⁻¹' (Set.Iic c).
---   (2) Bounded: coercivity gives R with SublevelSet V c ⊆ closedBall 0 R.
---   (3) Heine-Borel in ℝⁿ: closed + bounded = compact.
+/-- Sublevel sets of a radially unbounded continuous function are compact.
+
+Proof:
+1. Closed: `V ⁻¹' (Set.Iic c)`.
+2. Bounded: coercivity gives `R` with `SublevelSet V c ⊆ closedBall 0 R`.
+3. Heine-Borel in `ℝⁿ`: closed + bounded = compact. -/
+@[blueprint "lem:isCompact-sublevel-set"
+  (statement := /-- Let $V : \mathbb{R}^{n} \to \mathbb{R}$ be continuous and
+    radially unbounded. Then for every $c \in \mathbb{R}$ the sublevel set
+    $\Omega_{c}(V) = \{x : V(x) \le c\}$ (see \cref{def:sublevelSet}) is
+    compact. -/)
+  (proof := /-- $\Omega_{c}(V)$ is closed as the preimage of $(-\infty, c]$
+    under the continuous map $V$. Radial unboundedness gives a compact
+    $K \subseteq \mathbb{R}^{n}$ outside of which $V(x) > c$, so $\Omega_{c}(V)
+    \subseteq K$ and $\Omega_{c}(V)$ is bounded. By Heine-Borel in
+    $\mathbb{R}^{n}$, a closed and bounded set is compact. -/)]
 lemma isCompact_sublevel_set
     (V : ℝⁿ → ℝ) (hcont : Continuous V)
     (hradial : Filter.Tendsto V (Filter.comap norm Filter.atTop) Filter.atTop)
@@ -177,6 +321,19 @@ Proof sketch: V = ψ · V₀ where ψ : ℝⁿ → ℝ is a ContDiffBump functio
 ψ = 1 near x₀ and supp ψ compactly contained in D. Since supp ψ ⊆ D and ψ
 vanishes near ∂D, the product ψ · V₀ is globally C¹. -/
 
+/-- A `C¹` function on an open neighborhood extends to a globally `C¹`
+function agreeing with it on a neighborhood of the chosen point. -/
+@[blueprint "lem:contDiffOn-extension"
+  (statement := /-- Let $D \subseteq \mathbb{R}^{n}$ be open with
+    $x_{0} \in D$, and let $V_{0} : \mathbb{R}^{n} \to \mathbb{R}$ be of class
+    $C^{1}$ on $D$. There exist a globally $C^{1}$ function $V :
+    \mathbb{R}^{n} \to \mathbb{R}$ and an open neighborhood $D' \subseteq D$
+    of $x_{0}$ such that $V$ agrees with $V_{0}$ on $D'$. -/)
+  (proof := /-- Multiply $V_{0}$ by a smooth bump $\psi : \mathbb{R}^{n} \to
+    \mathbb{R}$ supported in $D$ and equal to $1$ on a neighborhood $D'$ of
+    $x_{0}$. The product $\psi \cdot V_{0}$ extends by zero to a globally
+    $C^{1}$ function on $\mathbb{R}^{n}$, and it agrees with $V_{0}$ on the
+    set $\{\psi = 1\} \supseteq D'$. -/)]
 lemma contDiffOn_extension
     {D : Set ℝⁿ} (hD : IsOpen D) {x₀ : ℝⁿ} (hx₀ : x₀ ∈ D)
     {V₀ : ℝⁿ → ℝ} (hV : ContDiffOn ℝ 1 V₀ D) :

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -71,3 +71,55 @@ kernel of the observability matrix.
 \inputleannode{def:hautusControllabilityMatrix}
 
 \inputleannode{thm:isControllable-iff-hautus}
+
+\chapter{Lyapunov stability}
+
+\section{Trajectories, equilibria, and comparison functions}
+
+\inputleannode{def:isTrajectory}
+
+\inputleannode{def:isEquilibrium}
+
+\inputleannode{def:isClassK}
+
+\inputleannode{def:isClassKInfty}
+
+\section{Stability predicates}
+
+\inputleannode{def:lyapunovStable}
+
+\inputleannode{def:localAsymptoticStable}
+
+\inputleannode{def:globalAsymptoticStable}
+
+\section{Sublevel sets and positive invariance}
+
+\inputleannode{def:sublevelSet}
+
+\inputleannode{def:isPositivelyInvariant}
+
+\inputleannode{lem:isCompact-sublevel-set}
+
+\inputleannode{lem:contDiffOn-extension}
+
+\section{Lyapunov functions}
+
+\inputleannode{def:isLocalLyapunovFunction}
+
+\inputleannode{def:isStrictLocalLyapunovFunction}
+
+\inputleannode{def:isStrictLyapunovFunction}
+
+\inputleannode{def:isGlobalLyapunovFunction}
+
+\inputleannode{def:isAsymptoticLyapunovFunction}
+
+\section{Milestone theorems for autonomous systems}
+
+\inputleannode{thm:lyapunov-stable}
+
+\inputleannode{thm:lyapunov-local-asymptotic-stable}
+
+\inputleannode{thm:lyapunov-asymptotic-stable}
+
+\inputleannode{thm:lyapunov-global-asymptotic-stable}


### PR DESCRIPTION
Adds @[blueprint] annotations to every declaration in LeanForControl/Lyapunov/Defs.lean (15 items: comparison functions, trajectories, stability predicates, sublevel sets, invariance, and the five Lyapunov-function structures, plus the two helper lemmas) and to the four milestone theorems in LeanForControl/Lyapunov/Autonomous.lean (lyapunov_stable, lyapunov_local_asymptotic_stable, lyapunov_asymptotic_stable, lyapunov_global_asymptotic_stable).

Wires the two modules into the docbuild root LeanForControl.lean so their doc-gen4 pages render.

Adds a new "Lyapunov stability" chapter to blueprint/src/content.tex referencing all 20 new \inputleannode labels.

LaSalles.lean is intentionally not covered in this PR and is not imported into the root.